### PR TITLE
Djbower/time debug

### DIFF
--- a/src/bin/Citcom.c
+++ b/src/bin/Citcom.c
@@ -194,11 +194,28 @@ int main(argc,argv)
 
   /* DJB TIME */
   age_Ma = E->control.start_age; // initialise
+
+  // DJB debugging
+  if (E->parallel.me == 0)  {
+      fprintf(E->fp,"DJB debug age_Ma %g\n",age_Ma); // Input parameters taken from file '%s'\n",argv[1]);
+      //fprintf(stderr,"Initialization complete after %g seconds\n\n",initial_time);
+      //fprintf(E->fp,"Initialization complete after %g seconds\n\n",initial_time);
+      fflush(E->fp);
+  }
+
   if (E->data.timedir >=0) {
       target_age_Ma = E->control.start_age - E->control.record_every_Myr;
   }
   else{
       target_age_Ma = E->control.start_age + E->control.record_every_Myr;
+  }
+
+  // DJB debugging
+  if (E->parallel.me == 0)  {
+      fprintf(E->fp,"DJB debug target_age_Ma %g\n",target_age_Ma); // Input parameters taken from file '%s'\n",argv[1]);
+      //fprintf(stderr,"Initialization complete after %g seconds\n\n",initial_time);
+      //fprintf(E->fp,"Initialization complete after %g seconds\n\n",initial_time);
+      fflush(E->fp);
   }
 
   /* this section advances the time step;
@@ -255,6 +272,14 @@ int main(argc,argv)
                 target_age_Ma += E->control.record_every_Myr; // update
             }
         }
+    }
+
+    // DJB debugging
+    if (E->parallel.me == 0)  {
+      fprintf(E->fp,"DJB debug age_Ma %g\n",age_Ma); // Input parameters taken from file '%s'\n",argv[1]);
+      fprintf(E->fp,"DJB debug dim_output %d\n",dim_output); // Input parameters taken from file '%s'\n",argv[1]);
+      fprintf(E->fp,"DJB debug target_age_Ma %g\n",target_age_Ma); // Input parameters taken from file '%s'\n",argv[1]);
+      fflush(E->fp);
     }
 
     /* DJB TIME now an additional condition to exit the loop */

--- a/src/bin/Citcom.c
+++ b/src/bin/Citcom.c
@@ -70,9 +70,13 @@ int main(argc,argv)
   double CPU_time0(),time,initial_time,start_time;
 
   /* DJB TIME */
-  double age_Ma; // initialised below
-  double target_age_Ma; // initialised below
-  int dim_output=0; // initialised
+  /* parameters for outputting data every dimensional time unit */
+  double age_Ma = 0.0;
+  /* beyond age_min_Ma, outputs occur every time step since it's the 
+   * simplest way to obtain output close to 0 Ma (but not negative ages) */
+  double age_min_Ma = 0.2; // minimum dimensional age
+  double target_age_Ma = 0.0;
+  int dim_output = 0;
 
   struct All_variables *E;
   MPI_Comm world;
@@ -83,7 +87,6 @@ int main(argc,argv)
     fprintf(stderr,"Usage: %s PARAMETERFILE\n", argv[0]);
     parallel_process_termination();
   }
-
 
 
   /* this section reads input, allocates memory, and set some initial values;
@@ -120,8 +123,6 @@ int main(argc,argv)
 
   /* write all config parameters to a file named pidXXXXXXXXX */
   print_all_config_parameters(E);
-
-
 
   /* this section sets the initial condition;
    * replaced by CitcomS.Controller.launch() ->
@@ -161,26 +162,36 @@ int main(argc,argv)
       need_init_sol = 1;	/*  */
   }
 
-  /* DJB TIME */
-  age_Ma = find_age_in_MY(E); // current age
-  target_age_Ma = E->control.start_age;
-  /* calculate new target age for output in Ma */
-  if (E->data.timedir >=0) {
-    while( target_age_Ma > age_Ma ){
-      target_age_Ma -= E->control.record_every_Myr;
-    }
-  }
-  else{
-    while( target_age_Ma < age_Ma ){
-      target_age_Ma += E->control.record_every_Myr;
-    }
+  /* DJB TIME flag for dimensional time output */
+  if(E->control.record_every_Myr!=0){
+      /* DJB TIME */
+      age_Ma = find_age_in_MY(E); // current age
+      /* loop to find the next target age, accounting for the
+       * current age */
+      target_age_Ma = E->control.start_age; /* starting point */
+      /* calculate new target age for output in Ma */
+      if (E->data.timedir >=0) {
+        while( target_age_Ma > age_Ma ){
+          target_age_Ma -= E->control.record_every_Myr;
+        }
+      }
+      else{
+        while( target_age_Ma < age_Ma ){
+          target_age_Ma += E->control.record_every_Myr;
+         }
+      }
+      /* impose non-zero minimum target age to initiate outputs
+       * every time step */
+      target_age_Ma = max( target_age_Ma, age_min_Ma );
+      if( age_Ma < age_min_Ma )
+	      dim_output = 1; // prob not req for 1st step, but here for completeness
+      if (E->parallel.me == 0)  {
+        fprintf(E->fp,"Output: Current age (Ma) = %g\n",age_Ma);
+        fprintf(E->fp,"Output: Next output age (Ma) = %g\n",target_age_Ma);
+        fflush(E->fp);
+      }
   }
 
-  if (E->parallel.me == 0)  {
-      fprintf(E->fp,"Output: Current age (Ma) = %g\n",age_Ma);
-      fprintf(E->fp,"Output: Next output age (Ma) = %g\n",target_age_Ma);
-      fflush(E->fp);
-  }
 
   if(need_init_sol){
     /* find first solution */
@@ -253,30 +264,33 @@ int main(argc,argv)
 
     /* DJB TIME flag for dimensional time output */
     if(E->control.record_every_Myr!=0){
-        if (E->data.timedir >= 0) { /* forward convection */
-            age_Ma = E->control.start_age - E->monitor.elapsed_time*E->data.scalet;
+        age_Ma = find_age_in_MY(E); // current age
+    	if (E->data.timedir >= 0) { /* forward convection */
 	    if( age_Ma < target_age_Ma ){
                 dim_output = 1; // update
                 target_age_Ma -= E->control.record_every_Myr; // update
             }        
         }
         else { /* backward convection */
-            age_Ma = E->control.start_age + E->monitor.elapsed_time*E->data.scalet;
             if( age_Ma > target_age_Ma ){
                 dim_output = 1; // update
                 target_age_Ma += E->control.record_every_Myr; // update
             }
         }
+	/* impose non-zero minimum target age to initiate outputs
+	 * every time step */
+	target_age_Ma = max( target_age_Ma, age_min_Ma );
+        if( age_Ma < age_min_Ma )
+	      dim_output = 1; // always output when close to zero age
+	/* DJB TIME */
+        if (dim_output && E->parallel.me == 0)  {
+            fprintf(E->fp,"Output: Current age (Ma) = %g\n",age_Ma);
+            fprintf(E->fp,"Output: Next output age (Ma) = %g\n",target_age_Ma);
+            fflush(E->fp);
+    	}
     }
 
-    /* DJB TIME */
-    if (dim_output && E->parallel.me == 0)  {
-        fprintf(E->fp,"Output: Current age (Ma) = %g\n",age_Ma);
-        fprintf(E->fp,"Output: Next output age (Ma) = %g\n",target_age_Ma);
-        fflush(E->fp);
-    }
-
-    /* DJB TIME now an additional condition to exit the loop */
+    /* DJB TIME now an additional condition to exit the loop (age_Ma) */
     if( (E->control.exit_at_present) && (E->data.timedir >= 0) && (age_Ma<0.0) ){
         E->control.keep_going = 0;
     }
@@ -340,11 +354,6 @@ int main(argc,argv)
       fprintf(E->fp,"CPU total = %g & CPU = %g for step %d time = %.4e dt = %.4e  maxT = %.4e sub_iteration%d\n",CPU_time0()-start_time,CPU_time0()-time,E->monitor.solution_cycles,E->monitor.elapsed_time,E->advection.timestep,E->monitor.T_interior,E->advection.last_sub_iterations);
 
       time = CPU_time0();
-
-      /* DJB TIME */
-      if(E->control.record_every_Myr!=0){
-        fprintf(E->fp, "Current age = %g Ma\n", age_Ma);
-      }
 
     }
 

--- a/src/bin/Citcom.c
+++ b/src/bin/Citcom.c
@@ -260,7 +260,8 @@ int main(argc,argv)
     if(E->control.record_every_Myr!=0){
         if (E->data.timedir >= 0) { /* forward convection */
             age_Ma = E->control.start_age - E->monitor.elapsed_time*E->data.scalet;
-            if( (target_age_Ma-age_Ma) >= 0 ){
+            /* FIXME: since target age is wrong, this is always satisfied */
+	    if( (target_age_Ma-age_Ma) >= 0 ){
                 dim_output = 1; // update
                 target_age_Ma -= E->control.record_every_Myr; // update
             }        

--- a/src/lib/Instructions.c
+++ b/src/lib/Instructions.c
@@ -120,7 +120,7 @@ void initial_mesh_solver_setup(struct All_variables *E)
     allocate_velocity_vars(E);
     if(chatty)fprintf(stderr,"velocity vars done\n");
 
-    /* DJB - some of this timing information is subsequently overwritten
+    /* DJB - debug some of this timing information is subsequently overwritten
      * if the user choses to restart from a checkpoint file */
     get_initial_elapsed_time(E);  /* Set elapsed time */
     set_starting_age(E);  /* set the starting age to elapsed time, if desired */

--- a/src/lib/Instructions.c
+++ b/src/lib/Instructions.c
@@ -120,7 +120,8 @@ void initial_mesh_solver_setup(struct All_variables *E)
     allocate_velocity_vars(E);
     if(chatty)fprintf(stderr,"velocity vars done\n");
 
-
+    /* DJB - some of this timing information is subsequently overwritten
+     * if the user choses to restart from a checkpoint file */
     get_initial_elapsed_time(E);  /* Set elapsed time */
     set_starting_age(E);  /* set the starting age to elapsed time, if desired */
     set_elapsed_time(E);         /* reset to elapsed time to zero, if desired */
@@ -133,7 +134,10 @@ void initial_mesh_solver_setup(struct All_variables *E)
       E->output.fpqt = E->output.fpqb = NULL;
     }
 
-
+    /* DJB - these functions are likely the cause of 'Age' and 'Velocity' outputs
+     * during the initialization routines (outputs in the log).  This adds some confusion
+     * regarding which times are actually used, since this occurs prior to potential
+     * time overwriting when reading in from checkpoint files */
 
     if(E->control.lith_age)
         lith_age_init(E);

--- a/src/lib/Problem_related.c
+++ b/src/lib/Problem_related.c
@@ -125,6 +125,7 @@ void get_initial_elapsed_time(E)
 
     E->monitor.elapsed_time = 0.0;
 
+    /* DJB - a checkpoint restart reads in the elapsed_time after this function */
     if (E->convection.tic_method == -1) {
 
 #ifdef USE_GZDIR		/* gzdir output */
@@ -185,9 +186,19 @@ void set_elapsed_time(E)
 void set_starting_age(E)
   struct All_variables *E;
 {
-/* remember start_age is in MY */
-    if (E->control.reset_startage)
-	E->control.start_age = E->monitor.elapsed_time*E->data.scalet;
+
+   /* remember start_age is in MY */
+    /* DJB: original is below, but this behaviour makes less sense since it does
+     * not account for the time direction, or the starting age specified in the
+     * input cfg file */
+   //if (E->control.reset_startage)
+   //   E->control.start_age = E->monitor.elapsed_time*E->data.scalet;
+
+   /* DJB TIME: instead, makes more sense to use find_age_in_MY(E), which
+    * accounts for the starting age in the cfg file, and the time
+    * direction */
+   if (E->control.reset_startage)
+      E->control.start_age = find_age_in_MY(E);
 
    return;
 }
@@ -205,6 +216,10 @@ void set_starting_age(E)
 {
    float age_in_MY, e_4;
 
+   /* DJB - debugging */
+   //if (E->parallel.me == 0) fprintf(stderr,"E->control.start_age = %g Ma\n",E->control.start_age);
+   //if (E->parallel.me == 0) fprintf(stderr,"E->monitor.elapsed_time = %g\n",E->monitor.elapsed_time);
+   //if (E->parallel.me == 0) fprintf(stderr,"E->data.scalet = %g\n",E->data.scalet);
 
    e_4=1.e-4;
 


### PR DESCRIPTION
@sabinz reported strange output behaviour when restarting from a check point.  This fix ensures that the next dimensional output (target) age is correctly determined at initialisation regardless if restarting from a velocity file or a check point file.  It also enforces outputs to occur for ages less than 0.2 Ma (this parameter is customisable, although currently hardcoded), to ensure that a final "nearly" zero (small positive) age is output.