### PR TITLE
Fix age-timestep missmatch with post processing

### DIFF
--- a/pre_post_processing/Core_Citcom.py
+++ b/pre_post_processing/Core_Citcom.py
@@ -1413,25 +1413,25 @@ from the list of tuples: (step, age, runtime) crated from a citcom time file.'''
             return (s,a,r)
 
     # list comprehension to compute the difference between test_age and model ages
-    # NOTE the if a-test_age > 0
-    delta_list = [a-test_age for (s,a,r) in triple_list if a-test_age > 0 ]
+    # JL - removed the below list comprehension as it assumes all times are in order (which doesn't seem to be the case)
+    # delta_list = [a-test_age for (s,a,r) in triple_list if a-test_age > 0 ]
 
-    # get index of, and delta from value to test for previous value
-    prev_i = len(delta_list) - 1
-    prev_delta = delta_list[-1]
+    # JL - delta_list should now be the same length as triples list
+    delta_list = []
+    i=0
+    for (s,a,r) in triple_list:
+        delta_list.append(a-test_age)
 
-    # get index of, and delta from value to test for next value
-    next_i = len(delta_list)
-    next_delta = triple_list[next_i][1] - test_age
+    # Index of closest value to requested time
+    # Not this is getting the absolute closest value which may result in rare edge cases where the same timestep is processed twice
+    i = np.abs(delta_list).argmin()
 
-    # index smallest delta and index into list of tuples
-    if abs(prev_delta) < abs(next_delta) :
-        i = prev_i
-    else: 
-        i = next_i
+    # This is now redundant but keeping it so the temrinal output is consistent
+    prev_i = i-1
+    next_i = i+1
 
-    # FIXME: ?
-    i = prev_i
+    prev_delta=delta_list[prev_i]
+    next_delta=delta_list[next_i]
 
     if verbose:
         print( Core_Util.now(), 'get_time_triple_from_age:', 'prev=', triple_list[prev_i], 'delta=', prev_delta, 'i=', prev_i )

--- a/pre_post_processing/grid_maker_parallel.py
+++ b/pre_post_processing/grid_maker_parallel.py
@@ -94,6 +94,11 @@ def main():
 
     control_d, pid_file, master_d, coor_d, pid_d, datadir, datafile, start_age, output_format, depth_list, nodez, nproc_surf = initialise_variables()
     
+    # print(master_d['time_d']['triples'][2])
+    # for t in master_d['time_d']['triples']:
+    #     print(int(t[1]))
+    # sys.exit()
+
     # Set the verbose settings
     if 'verbose' in control_d:
         print(f"{now()} Verbose is set to {control_d['verbose']} in the config file")
@@ -255,8 +260,12 @@ def main():
             #age_Ma = '%03d' % age_Ma
             age_Ma = str(age_Ma)
 
+        print(found_d)
+
+
         print(age_Ma)
         print('\n')
+
         if int(time) == int(age_Ma): # Think about changing this so it chooses the nearest age, but still doesn't double up
             varList.append((tt,f'{time}Ma',master_d, control_d, nproc_surf, datadir, datafile, level_spec_d, lon, lat, grid_list, depth_list, nodez, debug, pid_file, verbose))
         else:


### PR DESCRIPTION
The offending problem was from the function ‘get_time_triple_from_age’. This function takes the times to process (from the cfg file) and retrieves the timestep with the closest matching age.
 
The bit that went wrong was that it created a list of differences between ages until it got to zero:
delta_list = [a-test_age for (s,a,r) in triple_list if a-test_age > 0 ]
 
It then wanted to use the length of the resulting list as the index of the triple_list where the time matches the closest. The problem is that this only works if all the times are in order from largest to smallest. It appears that that isn’t the case. Is that unexpected behaviour? That the list of ages might not be in order?